### PR TITLE
Refactor release yml with for loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,15 @@ jobs:
       - name: Builds release
         shell: bash
         run: |
-          for release in linux-x64 macos-x64 win-x64
           tag=$(git describe --tags --abbrev=0)
+          for release in linux-x64 macos-x64 win-x64
           do
-            echo Chirp-$tag-$release
+            echo 
+          release_os=Chirp-$tag-$release
           cd "Chirp.Razor"
-          dotnet publish Chirp.Razor.csproj --framework net7.0 --runtime "linux-x64" -c Release -o "release" /p:PublishTrimmed=true /p:PublishSingleFile=true
-          7z a -tzip "${{ github.workspace }}/Chirp.Razor/${release}.zip" "./${release}/*"
-          rm -r "${release}"
+          dotnet publish Chirp.Razor.csproj --framework net7.0 --runtime $release -c Release -o "$release_os" /p:PublishTrimmed=true /p:PublishSingleFile=true
+          7z a -tzip "${{ github.workspace }}/Chirp.Razor/${release_os}.zip" "./${release_os}/*"
+          rm -r "${release_os}"
           done
       - name: Set Tag
         run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
           do
             echo 
           release_os=Chirp-$tag-$release
-          cd "Chirp.Razor"
           dotnet publish Chirp.Razor.csproj --framework net7.0 --runtime $release -c Release -o "$release_os" /p:PublishTrimmed=true /p:PublishSingleFile=true
           7z a -tzip "${{ github.workspace }}/Chirp.Razor/${release_os}.zip" "./${release_os}/*"
           rm -r "${release_os}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           tag=$(git describe --tags --abbrev=0)
           cd "Chirp.Razor"
-          for release in linux-x64 macos-x64 win-x64
+          for release in linux-x64 osx-x64 win-x64
           do
             echo 
           release_os=Chirp-$tag-$release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tests: 
     uses: ./.github/workflows/build_and_test.yml
-  release-linux:
+  release:
     needs: ["tests"]
     runs-on: ubuntu-latest
     env:
@@ -25,90 +25,22 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 7.0.*
-
-      - name: Build for Linux
+      - name: Builds release
         shell: bash
         run: |
+          for release in linux-x64 macos-x64 win-x64
           tag=$(git describe --tags --abbrev=0)
-          release_name_linux="Chirp-$tag-linux-x64"
+          do
+            echo Chirp-$tag-$release
           cd "Chirp.Razor"
-          dotnet publish Chirp.Razor.csproj --framework net7.0 --runtime "linux-x64" -c Release -o "$release_name_linux" /p:PublishTrimmed=true /p:PublishSingleFile=true
-          7z a -tzip "${{ github.workspace }}/Chirp.Razor/${release_name_linux}.zip" "./${release_name_linux}/*"
-          rm -r "${release_name_linux}"
+          dotnet publish Chirp.Razor.csproj --framework net7.0 --runtime "linux-x64" -c Release -o "release" /p:PublishTrimmed=true /p:PublishSingleFile=true
+          7z a -tzip "${{ github.workspace }}/Chirp.Razor/${release}.zip" "./${release}/*"
+          rm -r "${release}"
+          done
       - name: Set Tag
         run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
-      - name: Publish for Linux
-        uses: softprops/action-gh-release@v1
-        with:
-          files:  |
-           ${{ github.workspace }}/Chirp.Razor/Chirp-*.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release-macos:
-    needs: ["tests"]
-    runs-on: ubuntu-latest
-    env:
-      DOTNET_ROOT: /home/runner/.dotnet
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 7.0.*
-
-      - name: Build for macOS
-        shell: bash
-        run: |
-          tag=$(git describe --tags --abbrev=0)
-          release_name_macos="Chirp-$tag-macos-x64"
-          cd "Chirp.Razor"
-          dotnet publish Chirp.Razor.csproj --framework net7.0 --runtime "osx-x64" -c Release -o "$release_name_macos" /p:PublishTrimmed=true /p:PublishSingleFile=true
-          7z a -tzip "${{ github.workspace }}/Chirp.Razor/${release_name_macos}.zip" "./${release_name_macos}/*"
-          rm -r "${release_name_macos}"
-      - name: Set Tag
-        run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-
-      - name: Publish for macOS
-        uses: softprops/action-gh-release@v1
-        with:
-          files:  |
-            ${{ github.workspace }}/Chirp.Razor/Chirp-*.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-  release-windows:
-    needs: ["tests"]
-    runs-on: ubuntu-latest
-    env:
-      DOTNET_ROOT: C:\Users\runneradmin\AppData\Local\Microsoft\dotnet
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 7.0.*
-
-      - name: Build for Windows
-        shell: bash
-        run: |
-          tag=$(git describe --tags --abbrev=0)
-          release_name_windows="Chirp-$tag-win-x64"
-          cd "Chirp.Razor"
-          dotnet publish Chirp.Razor.csproj --framework net7.0 --runtime "win-x64" -c Release -o "$release_name_windows"  /p:PublishTrimmed=true /p:PublishSingleFile=true
-          7z a -tzip "${{ github.workspace }}/Chirp.Razor/${release_name_windows}.zip" "./${release_name_windows}/*" 
-          rm -r "${release_name_windows}"
-          
-      - name: Set Tag
-        run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-
-      - name: Publish for Windows
+      - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
           files:  |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         shell: bash
         run: |
           tag=$(git describe --tags --abbrev=0)
+          cd "Chirp.Razor"
           for release in linux-x64 macos-x64 win-x64
           do
             echo 


### PR DESCRIPTION
I have refactored the yml release workflow. It now depends on all tests passing before running, furthermore i have reduced all the redundant releases so we have no code duplication and instead a for loop that iterates the build for each release version. Lastly i have fixed the release push condition so it doesnt run the release workflow on both regular pushes AND tag pushes but instead ONLY on tag pushes. This means that the release workflow will ONLY RUN once a tag has been pushed. 